### PR TITLE
add finally block to patch context manager

### DIFF
--- a/cinspect/_patch_helpers.py
+++ b/cinspect/_patch_helpers.py
@@ -11,6 +11,8 @@ def inspect_restored():
     igetfile = inspect.getfile
     inspect.getsource = _igetsource
     inspect.getfile = _igetfile
-    yield
-    inspect.getsource = igetsource
-    inspect.getfile = igetfile
+    try:
+        yield
+    finally:
+        inspect.getsource = igetsource
+        inspect.getfile = igetfile


### PR DESCRIPTION
I was having trouble with monkey patching inspect - this change makes the patch helper that comes with cinspect work as I interpret it's expected to.